### PR TITLE
Removing provisioner tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```hcl
 module "lambda" {
-    source = "github.com/pbs/terraform-aws-lambda-module?ref=0.0.2"
+    source = "github.com/pbs/terraform-aws-lambda-module?ref=x.y.z"
 }
 ```
 
@@ -24,7 +24,7 @@ Integrate this module like so:
 
 ```hcl
 module "role" {
-  source = "github.com/pbs/terraform-aws-lambda-module?ref=0.0.2"
+  source = "github.com/pbs/terraform-aws-lambda-module?ref=x.y.z"
 
   handler  = "main"
   filename = "../artifacts/handler.zip"
@@ -44,7 +44,7 @@ module "role" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.0.2`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 

--- a/locals.tf
+++ b/locals.tf
@@ -27,7 +27,6 @@ locals {
       "${var.organization}:billing:product"     = var.product
       "${var.organization}:billing:environment" = var.environment
       creator                                   = local.creator
-      provisioner                               = data.aws_caller_identity.current.user_id
       repo                                      = var.repo
     }
   )


### PR DESCRIPTION
This tag doesn't help much, and causes issues with dependencies updating in weird orders.