### PR TITLE
Adjusting SSM path to align with ECS implementation

### DIFF
--- a/examples/ssm/main.tf
+++ b/examples/ssm/main.tf
@@ -1,10 +1,10 @@
 locals {
   # This is the default SSM path for Lambdas created like this.
-  ssm_path = "/${var.environment}/${var.product}"
+  ssm_path = "/${var.environment}/${var.product}/"
 }
 
 resource "aws_ssm_parameter" "name" {
-  name  = "${local.ssm_path}/name"
+  name  = "${local.ssm_path}name"
   type  = "SecureString"
   value = "John"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   name = var.name != null ? var.name : var.product
 
-  ssm_path         = var.ssm_path != null ? var.ssm_path : "/${var.environment}/${local.name}"
+  ssm_path         = var.ssm_path != null ? var.ssm_path : "/${var.environment}/${local.name}/"
   environment_vars = var.environment_vars != null ? var.environment_vars : { "SSM_PATH" = local.ssm_path }
   environment_map  = length(local.environment_vars) == 0 ? toset([]) : toset([local.environment_vars])
 

--- a/security.tf
+++ b/security.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "default_policy_document" {
     ]
     resources = [
       "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_path}",
-      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_path}/*"
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_path}*"
     ]
   }
 


### PR DESCRIPTION
In the ECS task definition module:
https://github.com/pbs/terraform-aws-ecs-task-definition-module/blob/main/locals.tf#L6

We use an SSM path that has a trailing slash, whereas we don't here.

We should try to align the implementation between the two for the sake of consistency.

Note that this is a breaking change, as folks might have source code for their lambdas that assumes an `SSM_PATH` that doesn't have a trailing slash.

